### PR TITLE
fix bug : cannot update param is struct type

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -92,10 +92,11 @@ type EntityGetAWSUploadKeyData struct {
 	TempAccessSecret string `json:"temp_access_secret"`
 }
 type ExtendMetadata struct {
-	MovieCategory string  `json:"movie_category,omitempty"`
-	IMDBScore     float64 `json:"imdb_score,omitempty"`
-	PublishedYear string  `json:"published_year,omitempty"`
+	MovieCategory string  `json:"movie_category,omitempty" form:"movie_category"`
+	IMDBScore     float64 `json:"movie_category,omitempty" form:"imdb_score"`
+	PublishedYear string  `json:"movie_category,omitempty" form:"published_year"`
 }
+
 type EntityData struct {
 	ID               string            `json:"id,omitempty"`
 	Name             string            `json:"name,omitempty"`
@@ -153,9 +154,9 @@ type EntityUpdateParams struct {
 	Poster           *string         `form:"poster"`
 	Thumbnail        *string         `form:"thumbnail"`
 	ExtendMetadata   *ExtendMetadata `form:"extendMetadata"`
-	MasterTaskID     *string         `form:"masterTaskId,omitempty"`
-	StandardTaskID   *string         `form:"standardTaskId,omitempty"`
-	ReadyToPublish   *PublishType    `form:"readyToPublish,omitempty"`
+	MasterTaskID     *string         `form:"masterTaskId"`
+	StandardTaskID   *string         `form:"standardTaskId"`
+	ReadyToPublish   *PublishType    `form:"readyToPublish"`
 }
 
 type EntityIdResponse struct {

--- a/live.go
+++ b/live.go
@@ -50,8 +50,8 @@ type PublishSocialLink struct {
 	streamKey string
 }
 type PullInfo struct {
-	PrimaryInputUri   string `json:"primaryInputUri"`
-	SecondaryInputUri string `json:"secondaryInputUri"`
+	PrimaryInputUri   string `json:"primaryInputUri" form:"primaryInputUri"`
+	SecondaryInputUri string `json:"secondaryInputUri" form:"secondaryInputUri"`
 }
 type LiveCreateParams struct {
 	Params            `form:"*"`
@@ -142,8 +142,8 @@ type LiveUpdateParams struct {
 }
 
 type PushInfo struct {
-	StreamKey string `json:"streamKey"`
-	StreamUrl string `json:"streamUrl"`
+	StreamKey string `form:"streamKey" json:"streamKey"`
+	StreamUrl string `form:"streamUrl" json:"streamUrl"`
 }
 
 type LiveListRecordedParams struct {


### PR DESCRIPTION
Hi,
I Push an PR for fixing isssue
 - cannot update when the param input has a struct param

Here is example :
```
       var extendMetadata = &uiza.ExtendMetadata{
		MovieCategory: "1111111111",
		IMDBScore:     79500,
	}
	params := &uiza.EntityUpdateParams{
		ID:             uiza.String("entityID"),
		ExtendMetadata: extendMetadata,
	}
       response, err := entity.Update(params)
```
       It will parse extendMetadata to : extendMetadata[MovieCategory] :{IMDBScore:79500}. 

It will make the body of the request is wrong
```
{
   id:entityID,
   extendMetadata[IMDBScore]:79500,
   extendMetadata[MovieCategory]:1111111111,
}
```
It just correct it to : 
```
{
   id:entityID,
   extendMetadata: {
      IMDBScore:79500,
      MovieCategory:1111111111
   }
}
```

